### PR TITLE
Modify type of response.data of bedrock function 'image_generation'

### DIFF
--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -1511,7 +1511,7 @@ def image_generation(
 
     image_list: List = []
     for artifact in response_body["artifacts"]:
-        image_dict = {"url": artifact["base64"]}
+        image_dict = [{"url": artifact["base64"]}]
+        model_response.data += image_dict
 
-    model_response.data = image_dict
     return model_response


### PR DESCRIPTION
## Modify type of response.data of bedrock function 'image_generation'

## Type

🐛 Bug Fix

## Changes

Make the model_response.data a list type rather than a dict. Refer to [OpenAI docs](https://platform.openai.com/docs/api-reference/images/create)

